### PR TITLE
Fix null reference exception when displaying Reflection related errors

### DIFF
--- a/Routine.cs
+++ b/Routine.cs
@@ -78,11 +78,16 @@ namespace AsyncRoutines
 						return "(unknown) at unknown:0:0";
 					}
 
-					var filePath = frame.GetFileName().Replace("\\", "/");
-					var assetsIndex = filePath.IndexOf("/Assets/");
-					if (assetsIndex >= 0)
-					{
-						filePath = filePath.Substring(assetsIndex + 1);
+					var filePath = frame.GetFileName();
+					if (filePath != null) {
+						filePath = filePath.Replace("\\", "/");
+						var assetsIndex = filePath.IndexOf("/Assets/");
+						if (assetsIndex >= 0) {
+							filePath = filePath.Substring(assetsIndex + 1);
+						}
+					}
+					else {
+						filePath = "<filename unknown>";
 					}
 
 					return string.Format(

--- a/Routine.cs
+++ b/Routine.cs
@@ -79,14 +79,17 @@ namespace AsyncRoutines
 					}
 
 					var filePath = frame.GetFileName();
-					if (filePath != null) {
+					if (filePath != null) 
+					{
 						filePath = filePath.Replace("\\", "/");
 						var assetsIndex = filePath.IndexOf("/Assets/");
-						if (assetsIndex >= 0) {
+						if (assetsIndex >= 0) 
+						{
 							filePath = filePath.Substring(assetsIndex + 1);
 						}
 					}
-					else {
+					else 
+					{
 						filePath = "<filename unknown>";
 					}
 


### PR DESCRIPTION
I ran into an issue where an error using Reflection in a routine caused a NullReferenceException in the Routine error handling logic since frame.GetFileName() returned null.

**Proposed fix:**
When the file is null, display "filename unknown" instead of processing the file path

It is still useful to display the error since the type and method name are available.